### PR TITLE
Endpoint da prova de consistencia

### DIFF
--- a/bu_backend/src/adapters/merkletree.adapter.js
+++ b/bu_backend/src/adapters/merkletree.adapter.js
@@ -76,7 +76,8 @@ exports.getProof = (firstTreeSize, secondTreeSize) => {
   .then(res => {
     return {
       proof_path: res.data.path,
-      tree_root: res.data.tree_root
+      first_tree_hash: res.data.first_hash,
+      second_tree_hash: res.data.second_hash
     }
   })
   .catch(err => {

--- a/bu_backend/src/adapters/merkletree.adapter.js
+++ b/bu_backend/src/adapters/merkletree.adapter.js
@@ -72,7 +72,7 @@ exports.getAllLeaves = () => {
 }
 
 exports.getProof = (firstTreeSize) => {
-  return axios.get(`${merkletreeHostname}:${merkletreePort}/tree/proof?m=${firstTreeSize}`)
+  return axios.get(`${merkletreeHostname}:${merkletreePort}/tree/proof?initial=${firstTreeSize}`)
   .then(res => {
     return res.data
   })

--- a/bu_backend/src/adapters/merkletree.adapter.js
+++ b/bu_backend/src/adapters/merkletree.adapter.js
@@ -71,10 +71,13 @@ exports.getAllLeaves = () => {
     })
 }
 
-exports.getProof = (firstTreeSize) => {
-  return axios.get(`${merkletreeHostname}:${merkletreePort}/tree/proof?initial=${firstTreeSize}`)
+exports.getProof = (firstTreeSize, secondTreeSize) => {
+  return axios.get(`${merkletreeHostname}:${merkletreePort}/tree/proof?initial=${firstTreeSize}&final=${secondTreeSize}`)
   .then(res => {
-    return res.data
+    return {
+      proof_path: res.data.path,
+      tree_root: res.data.tree_root
+    }
   })
   .catch(err => {
     console.log(err)

--- a/bu_backend/src/controllers/bu.controller.js
+++ b/bu_backend/src/controllers/bu.controller.js
@@ -28,7 +28,7 @@ const consistencyProofData = {
 }
 
 const TAM_MTREE_PARCIAL = 4
-const QTD_BUs_CONSISTENCY_PROOF = TAM_MTREE_PARCIAL //Frequência de envio da prova de consistência
+const QTD_BUs_CONSISTENCY_PROOF = 4 //Frequência de envio da prova de consistência
 /* ----------------------------------- */
 
 // Create and Save a new BU
@@ -45,7 +45,11 @@ exports.create = (data) => {
       ...data
     })
     publishConsistencyCheck(merkletree_data.added_leaf)
-    publishConsistencyProof()    
+
+    consistencyProofData.tree_size_2++ 
+    if(consistencyProofData.tree_size_2 % QTD_BUs_CONSISTENCY_PROOF == 0){
+      publishConsistencyProof(consistencyProofData.tree_size_1, consistencyProofData.tree_size_2)
+    }
   })
   return
 };
@@ -161,23 +165,15 @@ function publishConsistencyCheck(BUAdicionado){
 * publishConsistencyProof
 * @desc - Processa e envia a prova de consistência a cada inserção de BU
 */
-function publishConsistencyProof(){
-  consistencyProofData.tree_size_2++ //A cada BU inserido, o tamanho da árvore a ser provada aumenta
-  if(consistencyProofData.tree_size_2 % QTD_BUs_CONSISTENCY_PROOF == 0){ 
-    //Enviar prova de consistência
-    merkletree_adapter.getProof(consistencyProofData.tree_size_1).then((proof) => {
-      //Obtendo os dados necessários para realizar a prova
-      consistencyProofData.consistency_path = proof
-      merkletree_adapter.getTreeRoot().then((treeRoot => {
-        //Obtendo raiz atual
-        consistencyProofData.second_hash = treeRoot
-        publish('logs-transparentes/consistencyProof', JSON.stringify(consistencyProofData))
-        console.log("\n\nPublicado prova de consistência")
-        console.log(JSON.stringify(consistencyProofData))
-        consistencyProofData.first_hash = consistencyProofData.second_hash
-        consistencyProofData.tree_size_1 = consistencyProofData.tree_size_2
-        consistencyProofData.log_id ++
-      }))
-    })
-  }
+function publishConsistencyProof(tree_size_1, tree_size_2){
+  merkletree_adapter.getProof(tree_size_1, tree_size_2).then(({proof_path, tree_root}) => {
+    consistencyProofData.consistency_path = proof_path
+    consistencyProofData.second_hash = tree_root
+    publish('logs-transparentes/consistencyProof', JSON.stringify(consistencyProofData))
+    consistencyProofData.tree_size_1 = consistencyProofData.tree_size_2
+    consistencyProofData.first_hash = consistencyProofData.second_hash
+    consistencyProofData.log_id ++
+    console.log("\n\nPublicado prova de consistência")
+    console.log(JSON.stringify(consistencyProofData))
+  })
 }

--- a/bu_backend/src/controllers/bu.controller.js
+++ b/bu_backend/src/controllers/bu.controller.js
@@ -31,9 +31,6 @@ const TAM_MTREE_PARCIAL = 4
 const QTD_BUs_CONSISTENCY_PROOF = TAM_MTREE_PARCIAL //Frequência de envio da prova de consistência
 /* ----------------------------------- */
 
-// const BU = db.bu;
-
-//const BU = db.bu;
 // Create and Save a new BU
 exports.create = (data) => {
   buString = data.turno + data.secao + data.zona + data.UF + JSON.stringify(data.votos)

--- a/bu_frontend/src/views/pages/Monitorar/logic/client.js
+++ b/bu_frontend/src/views/pages/Monitorar/logic/client.js
@@ -3,7 +3,7 @@ const mosquitto_url = require('../../../../config.json').mosquitto_url
 
 /* ---------------------- Configuração mqtt ------------------------- */
 const client  = mqtt.connect(mosquitto_url)
-
+client.setMaxListeners(0)
 client.on('connect', function () {
   client.subscribe('logs-transparentes/consistencyCheck', {qos: 0}, function (err) {
     if (!err) 

--- a/bu_frontend/src/views/pages/Monitorar/logic/client.js
+++ b/bu_frontend/src/views/pages/Monitorar/logic/client.js
@@ -5,11 +5,11 @@ const mosquitto_url = require('../../../../config.json').mosquitto_url
 const client  = mqtt.connect(mosquitto_url)
 client.setMaxListeners(0)
 client.on('connect', function () {
-  client.subscribe('logs-transparentes/consistencyCheck', {qos: 0}, function (err) {
+  client.subscribe('logs-transparentes/consistencyCheck', {qos: 2}, function (err) {
     if (!err) 
       console.log("Conectado ao tópico consistencyCheck")
   })
-  client.subscribe('logs-transparentes/consistencyProof', {qos: 0}, function (err) {
+  client.subscribe('logs-transparentes/consistencyProof', {qos: 2}, function (err) {
     if (!err) 
       console.log("Conectado ao tópico consistencyProof")
   })

--- a/bu_frontend/src/views/pages/Monitorar/logic/subscriberConsistency.js
+++ b/bu_frontend/src/views/pages/Monitorar/logic/subscriberConsistency.js
@@ -80,8 +80,8 @@ function inserirNoBuffer(data) {
 
 export function provaDeConsistencia(consistencyProofData){
   if(consistencyProofData.tree_size_1 == 0)
-    return new MerkleTree(consistencyProofData.consistency_path, SHA256).getRoot().toString('hex') === consistencyProofData.second_hash; 
-
+    return new MerkleTree(consistencyProofData.consistency_path, SHA256).getHexRoot() === consistencyProofData.second_hash; 
+  
   /* 1. If consistency_path is an empty array, stop and fail the proof verification. */
   if(consistencyProofData.consistency_path == null)
     return false

--- a/merkleTree/app.js
+++ b/merkleTree/app.js
@@ -2,17 +2,16 @@ const express = require('express')
 const { MerkleTree } = require('merkletreejs')
 const SHA256 = require('crypto-js/sha256')
 const consistencyProof = require('./controllers/consistencyProof.controller')
-var bodyParser = require('body-parser');
 
 // TODO: throtling
 // TODO: alguma otimizaçao para assinar a raiz (lru cache, ou assinar a cada X minutos)
 // TODO: 2 ataques na lib do merkltreejs (fork) -> prof simplicio vai explicar como corrige
 const app = express()
 app.use(express.json())
+
 const port = 3001
 //mudar a funcao de hash
 const tree = new MerkleTree([], SHA256)
-
 
 app.get('/', (req, res) => {
   res.send('Hello World!' + tree.toString())
@@ -86,8 +85,12 @@ app.get('/tree/root', (req, res) => {
 })
 
 app.get('/tree/proof', (req, res) => {
-  console.log(`Prova de consistência com m = ${req.query.m}`)
-  res.send(consistencyProof.proof(req.query.m, tree.getHexLeaves()))
+  if(req.query.final === undefined)
+    final = tree.getLeafCount()
+  else
+    final = req.query.final
+  console.log(`Prova de consistência com initial = ${req.query.initial} e final = ${final}`)
+  res.send(consistencyProof.proof(req.query.initial, tree.getHexLeaves().slice(0, final)))
 })
 
 app.get('/tree/leaf/:id', (req, res) => {

--- a/merkleTree/controllers/consistencyProof.controller.js
+++ b/merkleTree/controllers/consistencyProof.controller.js
@@ -20,7 +20,8 @@ function proof(m, D_n){
         return null
     return {
         path: path,
-        tree_root: MTH(D_n)
+        first_hash: MTH(D_n.slice(0, m)),
+        second_hash: MTH(D_n),
     }
 }
 

--- a/merkleTree/controllers/consistencyProof.controller.js
+++ b/merkleTree/controllers/consistencyProof.controller.js
@@ -9,12 +9,19 @@ const SHA256 = require('crypto-js/sha256')
 * @return {String[]}
 */
 function proof(m, D_n){
-    if(m == 0)
-        return D_n
+    let path
     n = D_n.length
-    if(m < n)
-        return __subProof(m, D_n, true)
-    return null
+
+    if(m == 0)
+        path = D_n
+    else if(m < n)
+        path = __subProof(m, D_n, true)
+    else
+        return null
+    return {
+        path: path,
+        tree_root: MTH(D_n)
+    }
 }
 
 /**


### PR DESCRIPTION
Tentei alterar o endpoint de modo que não interfira em nossa implementação atual.

Foi adicionado um parâmetro que define a quantidade de folhas da árvore no qual o monitor deseja verificar a consistência da raiz. 
É um parâmetro opcional, se oculto a aplicação leva em consideração a árvore atual armazenada no backend (como funcionava antes...).
Testei, e aparentemente está tudo funcionando como antes no front. Entretanto, é possível visualizar o funcionamento da feature acessando diretamente pelo navegador.