### PR TITLE
Versão de Dockerfile com imagem de tipo diferente (slim -> normal) para a instalação de dependências.

### DIFF
--- a/backend/bu_service/Dockerfile
+++ b/backend/bu_service/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.12.2-slim-bullseye AS build-stage
+FROM python:3.12.2-bullseye AS build-stage
 
 WORKDIR /app
 
-RUN apt update && apt install -y gcc
 COPY app/ /app/app
 COPY main.py /app
 COPY requirements.txt /app


### PR DESCRIPTION
O Dockerfile do bu_service foi modificado da seguinte forma:

- mudança de tipo de imagem para a fase de geração (build_stage) de "Debian slim Bullseye" para "Debian bullseye" integral. Ela já deve conter o gcc, dispensando sua instalação.

- remoção da instrução de instalação do gcc, que na versão integral jé deve estar presente.